### PR TITLE
RFC: Drop obsolete musl & alpine builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,11 +14,6 @@ permissions:
   packages: write # Needed to publish images to GHCR
 
 jobs:
-  alpine-base:
-    uses: ./.github/workflows/.build.yaml
-    with:
-      image: alpine-base
-      registry: ghcr.io/wolfi-dev/alpine-base
 
   apko:
     uses: ./.github/workflows/.build.yaml
@@ -27,24 +22,12 @@ jobs:
       melange-config: configs/latest.melange.yaml
       registry: ghcr.io/wolfi-dev/apko
 
-  gcc-musl:
-    uses: ./.github/workflows/.build.yaml
-    with:
-      image: gcc-musl
-      registry: ghcr.io/wolfi-dev/gcc-musl
-
   melange:
     uses: ./.github/workflows/.build.yaml
     with:
       image: melange
       melange-config: configs/latest.melange.yaml
       registry: ghcr.io/wolfi-dev/melange
-
-  musl-dynamic:
-    uses: ./.github/workflows/.build.yaml
-    with:
-      image: musl-dynamic
-      registry: ghcr.io/wolfi-dev/musl-dynamic
 
   sdk:
     uses: ./.github/workflows/.build.yaml


### PR DESCRIPTION
musl & alpine bases are no longer updated or supported, and probably should be withdrawn.

Unless I am mistaken, and people rely on these builds to be up to date, and/or we want to continue building these.